### PR TITLE
Fixing Konduto Order Status allowed_status

### DIFF
--- a/lib/konduto-ruby/konduto_order_status.rb
+++ b/lib/konduto-ruby/konduto_order_status.rb
@@ -2,6 +2,6 @@ class KondutoOrderStatus < KondutoBase
   attributes :status, :comments
 
   def self.allowed_status
-    %w(APPROVED DECLINED NOT_AUTHORIZED CANCELLED FRAUD)
+    %w(APPROVED DECLINED NOT_AUTHORIZED CANCELED FRAUD)
   end
 end


### PR DESCRIPTION
When sending `CANCELLED` status, the lib validates it, but returns error at Konduto.

Otherwise when sending `CANCELED` the lib does not validate it, but it's a correct status at Konduto.

Following the docs: http://docs.konduto.com/pt/#enviar-um-pedido